### PR TITLE
Implement Langfuse CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,21 @@
+# Python virtual environments
 .venv/
 venv/
+
+# Rust build artifacts
+/target
+Cargo.lock
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Environment
+.env
+.env.local
+
+# OS
+.DS_Store
+Thumbs.db

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "lf"
+version = "0.1.0"
+edition = "2021"
+description = "A command-line interface for Langfuse observability platform"
+authors = ["Langfuse CLI Contributors"]
+license = "MIT"
+
+[[bin]]
+name = "lf"
+path = "src/main.rs"
+
+[dependencies]
+# CLI framework
+clap = { version = "4", features = ["derive", "env"] }
+
+# Async runtime and HTTP
+tokio = { version = "1", features = ["full"] }
+reqwest = { version = "0.12", features = ["json"] }
+
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9"
+
+# Date/time parsing
+chrono = { version = "0.4", features = ["serde"] }
+
+# Output formatting
+tabled = "0.16"
+csv = "1.3"
+
+# Configuration
+directories = "5"
+dirs = "5"
+
+# Error handling
+thiserror = "2"
+anyhow = "1"
+
+# User input
+dialoguer = "0.11"
+
+# Environment
+dotenvy = "0.15"
+
+[profile.release]
+lto = true
+codegen-units = 1
+strip = true

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,493 @@
+use anyhow::{Context, Result};
+use reqwest::{Client, StatusCode};
+use serde::de::DeserializeOwned;
+use std::collections::HashMap;
+use thiserror::Error;
+
+use crate::config::Config;
+use crate::types::*;
+
+/// API errors
+#[derive(Error, Debug)]
+pub enum ApiError {
+    #[error("Authentication failed. Check your public and secret keys.")]
+    AuthenticationError,
+
+    #[error("Resource not found: {0}")]
+    NotFoundError(String),
+
+    #[error("Rate limit exceeded. Please try again later.")]
+    RateLimitError,
+
+    #[error("Request timeout")]
+    TimeoutError,
+
+    #[error("API error: {status} - {message}")]
+    ApiError { status: u16, message: String },
+
+    #[error("Network error: {0}")]
+    NetworkError(String),
+}
+
+/// Langfuse API client
+pub struct LangfuseClient {
+    client: Client,
+    host: String,
+    public_key: String,
+    secret_key: String,
+}
+
+impl LangfuseClient {
+    /// Create a new client from configuration
+    pub fn new(config: &Config) -> Result<Self> {
+        let public_key = config
+            .public_key
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("Public key is required"))?;
+        let secret_key = config
+            .secret_key
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("Secret key is required"))?;
+
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .build()
+            .context("Failed to create HTTP client")?;
+
+        Ok(Self {
+            client,
+            host: config.host.clone(),
+            public_key,
+            secret_key,
+        })
+    }
+
+    /// Make an authenticated GET request
+    async fn get<T: DeserializeOwned>(&self, path: &str, params: &[(&str, &str)]) -> Result<T> {
+        let url = format!("{}/api/public{}", self.host, path);
+
+        let mut request = self.client.get(&url).basic_auth(&self.public_key, Some(&self.secret_key));
+
+        if !params.is_empty() {
+            request = request.query(params);
+        }
+
+        let response = request.send().await.map_err(|e| {
+            if e.is_timeout() {
+                ApiError::TimeoutError
+            } else {
+                ApiError::NetworkError(e.to_string())
+            }
+        })?;
+
+        let status = response.status();
+
+        match status {
+            StatusCode::OK => {
+                let body = response
+                    .json::<T>()
+                    .await
+                    .context("Failed to parse response")?;
+                Ok(body)
+            }
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+                Err(ApiError::AuthenticationError.into())
+            }
+            StatusCode::NOT_FOUND => {
+                let message = response.text().await.unwrap_or_default();
+                Err(ApiError::NotFoundError(message).into())
+            }
+            StatusCode::TOO_MANY_REQUESTS => Err(ApiError::RateLimitError.into()),
+            _ => {
+                let message = response.text().await.unwrap_or_default();
+                Err(ApiError::ApiError {
+                    status: status.as_u16(),
+                    message,
+                }
+                .into())
+            }
+        }
+    }
+
+    /// Make an authenticated POST request
+    async fn post<T: DeserializeOwned, B: serde::Serialize>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<T> {
+        let url = format!("{}/api/public{}", self.host, path);
+
+        let response = self
+            .client
+            .post(&url)
+            .basic_auth(&self.public_key, Some(&self.secret_key))
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_timeout() {
+                    ApiError::TimeoutError
+                } else {
+                    ApiError::NetworkError(e.to_string())
+                }
+            })?;
+
+        let status = response.status();
+
+        match status {
+            StatusCode::OK => {
+                let body = response
+                    .json::<T>()
+                    .await
+                    .context("Failed to parse response")?;
+                Ok(body)
+            }
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+                Err(ApiError::AuthenticationError.into())
+            }
+            StatusCode::NOT_FOUND => {
+                let message = response.text().await.unwrap_or_default();
+                Err(ApiError::NotFoundError(message).into())
+            }
+            StatusCode::TOO_MANY_REQUESTS => Err(ApiError::RateLimitError.into()),
+            _ => {
+                let message = response.text().await.unwrap_or_default();
+                Err(ApiError::ApiError {
+                    status: status.as_u16(),
+                    message,
+                }
+                .into())
+            }
+        }
+    }
+
+    // ========== Traces API ==========
+
+    /// List traces with optional filters
+    pub async fn list_traces(
+        &self,
+        name: Option<&str>,
+        user_id: Option<&str>,
+        session_id: Option<&str>,
+        tags: Option<&[String]>,
+        from_timestamp: Option<&str>,
+        to_timestamp: Option<&str>,
+        limit: u32,
+        page: u32,
+    ) -> Result<Vec<Trace>> {
+        let mut all_traces = Vec::new();
+        let mut current_page = page;
+        let page_size = std::cmp::min(limit, 100);
+
+        loop {
+            let mut params: Vec<(&str, String)> = vec![
+                ("limit", page_size.to_string()),
+                ("page", current_page.to_string()),
+            ];
+
+            if let Some(n) = name {
+                params.push(("name", n.to_string()));
+            }
+            if let Some(u) = user_id {
+                params.push(("userId", u.to_string()));
+            }
+            if let Some(s) = session_id {
+                params.push(("sessionId", s.to_string()));
+            }
+            if let Some(from) = from_timestamp {
+                params.push(("fromTimestamp", from.to_string()));
+            }
+            if let Some(to) = to_timestamp {
+                params.push(("toTimestamp", to.to_string()));
+            }
+            if let Some(t) = tags {
+                for tag in t {
+                    params.push(("tags", tag.clone()));
+                }
+            }
+
+            let params_refs: Vec<(&str, &str)> =
+                params.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+            let response: TracesResponse = self.get("/traces", &params_refs).await?;
+
+            all_traces.extend(response.data);
+
+            if all_traces.len() >= limit as usize {
+                all_traces.truncate(limit as usize);
+                break;
+            }
+
+            if let Some(meta) = &response.meta {
+                if let Some(total_pages) = meta.total_pages {
+                    if current_page >= total_pages as u32 {
+                        break;
+                    }
+                }
+            }
+
+            current_page += 1;
+        }
+
+        Ok(all_traces)
+    }
+
+    /// Get a single trace by ID
+    pub async fn get_trace(&self, id: &str) -> Result<Trace> {
+        self.get(&format!("/traces/{}", id), &[]).await
+    }
+
+    // ========== Sessions API ==========
+
+    /// List sessions with optional filters
+    pub async fn list_sessions(
+        &self,
+        from_timestamp: Option<&str>,
+        to_timestamp: Option<&str>,
+        limit: u32,
+        page: u32,
+    ) -> Result<Vec<Session>> {
+        let mut all_sessions = Vec::new();
+        let mut current_page = page;
+        let page_size = std::cmp::min(limit, 100);
+
+        loop {
+            let mut params: Vec<(&str, String)> = vec![
+                ("limit", page_size.to_string()),
+                ("page", current_page.to_string()),
+            ];
+
+            if let Some(from) = from_timestamp {
+                params.push(("fromTimestamp", from.to_string()));
+            }
+            if let Some(to) = to_timestamp {
+                params.push(("toTimestamp", to.to_string()));
+            }
+
+            let params_refs: Vec<(&str, &str)> =
+                params.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+            let response: SessionsResponse = self.get("/sessions", &params_refs).await?;
+
+            all_sessions.extend(response.data);
+
+            if all_sessions.len() >= limit as usize {
+                all_sessions.truncate(limit as usize);
+                break;
+            }
+
+            if let Some(meta) = &response.meta {
+                if let Some(total_pages) = meta.total_pages {
+                    if current_page >= total_pages as u32 {
+                        break;
+                    }
+                }
+            }
+
+            current_page += 1;
+        }
+
+        Ok(all_sessions)
+    }
+
+    /// Get a single session by ID
+    pub async fn get_session(&self, id: &str) -> Result<Session> {
+        self.get(&format!("/sessions/{}", id), &[]).await
+    }
+
+    // ========== Observations API ==========
+
+    /// List observations with optional filters
+    pub async fn list_observations(
+        &self,
+        trace_id: Option<&str>,
+        name: Option<&str>,
+        observation_type: Option<&str>,
+        user_id: Option<&str>,
+        from_start_time: Option<&str>,
+        to_start_time: Option<&str>,
+        limit: u32,
+        page: u32,
+    ) -> Result<Vec<Observation>> {
+        let mut all_observations = Vec::new();
+        let mut current_page = page;
+        let page_size = std::cmp::min(limit, 100);
+
+        loop {
+            let mut params: Vec<(&str, String)> = vec![
+                ("limit", page_size.to_string()),
+                ("page", current_page.to_string()),
+            ];
+
+            if let Some(t) = trace_id {
+                params.push(("traceId", t.to_string()));
+            }
+            if let Some(n) = name {
+                params.push(("name", n.to_string()));
+            }
+            if let Some(ot) = observation_type {
+                params.push(("type", ot.to_string()));
+            }
+            if let Some(u) = user_id {
+                params.push(("userId", u.to_string()));
+            }
+            if let Some(from) = from_start_time {
+                params.push(("fromStartTime", from.to_string()));
+            }
+            if let Some(to) = to_start_time {
+                params.push(("toStartTime", to.to_string()));
+            }
+
+            let params_refs: Vec<(&str, &str)> =
+                params.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+            let response: ObservationsResponse = self.get("/observations", &params_refs).await?;
+
+            all_observations.extend(response.data);
+
+            if all_observations.len() >= limit as usize {
+                all_observations.truncate(limit as usize);
+                break;
+            }
+
+            if let Some(meta) = &response.meta {
+                if let Some(total_pages) = meta.total_pages {
+                    if current_page >= total_pages as u32 {
+                        break;
+                    }
+                }
+            }
+
+            current_page += 1;
+        }
+
+        Ok(all_observations)
+    }
+
+    /// Get a single observation by ID
+    pub async fn get_observation(&self, id: &str) -> Result<Observation> {
+        self.get(&format!("/observations/{}", id), &[]).await
+    }
+
+    // ========== Scores API ==========
+
+    /// List scores with optional filters
+    pub async fn list_scores(
+        &self,
+        name: Option<&str>,
+        from_timestamp: Option<&str>,
+        to_timestamp: Option<&str>,
+        limit: u32,
+        page: u32,
+    ) -> Result<Vec<Score>> {
+        let mut all_scores = Vec::new();
+        let mut current_page = page;
+        let page_size = std::cmp::min(limit, 100);
+
+        loop {
+            let mut params: Vec<(&str, String)> = vec![
+                ("limit", page_size.to_string()),
+                ("page", current_page.to_string()),
+            ];
+
+            if let Some(n) = name {
+                params.push(("name", n.to_string()));
+            }
+            if let Some(from) = from_timestamp {
+                params.push(("fromTimestamp", from.to_string()));
+            }
+            if let Some(to) = to_timestamp {
+                params.push(("toTimestamp", to.to_string()));
+            }
+
+            let params_refs: Vec<(&str, &str)> =
+                params.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+            let response: ScoresResponse = self.get("/scores", &params_refs).await?;
+
+            all_scores.extend(response.data);
+
+            if all_scores.len() >= limit as usize {
+                all_scores.truncate(limit as usize);
+                break;
+            }
+
+            if let Some(meta) = &response.meta {
+                if let Some(total_pages) = meta.total_pages {
+                    if current_page >= total_pages as u32 {
+                        break;
+                    }
+                }
+            }
+
+            current_page += 1;
+        }
+
+        Ok(all_scores)
+    }
+
+    /// Get a single score by ID
+    pub async fn get_score(&self, id: &str) -> Result<Score> {
+        self.get(&format!("/scores/{}", id), &[]).await
+    }
+
+    // ========== Metrics API ==========
+
+    /// Query metrics
+    pub async fn query_metrics(
+        &self,
+        view: &str,
+        measure: &str,
+        aggregation: &str,
+        dimensions: Option<&[String]>,
+        from_timestamp: Option<&str>,
+        to_timestamp: Option<&str>,
+        granularity: Option<&str>,
+        limit: Option<u32>,
+    ) -> Result<MetricsResult> {
+        let mut body: HashMap<String, serde_json::Value> = HashMap::new();
+
+        body.insert("view".to_string(), serde_json::json!(view));
+        body.insert("measure".to_string(), serde_json::json!(measure));
+        body.insert("aggregation".to_string(), serde_json::json!(aggregation));
+
+        if let Some(dims) = dimensions {
+            let dims_formatted: Vec<HashMap<String, String>> = dims
+                .iter()
+                .map(|d| {
+                    let mut m = HashMap::new();
+                    m.insert("field".to_string(), d.clone());
+                    m
+                })
+                .collect();
+            body.insert("dimensions".to_string(), serde_json::json!(dims_formatted));
+        }
+
+        if let Some(from) = from_timestamp {
+            body.insert("fromTimestamp".to_string(), serde_json::json!(from));
+        }
+        if let Some(to) = to_timestamp {
+            body.insert("toTimestamp".to_string(), serde_json::json!(to));
+        }
+        if let Some(g) = granularity {
+            body.insert("granularity".to_string(), serde_json::json!(g));
+        }
+        if let Some(l) = limit {
+            body.insert("limit".to_string(), serde_json::json!(l));
+        }
+
+        self.post("/metrics", &body).await
+    }
+
+    /// Test connectivity (used for config validation)
+    pub async fn test_connection(&self) -> Result<bool> {
+        // Try to list traces with limit 1 to test connection
+        let params = [("limit", "1")];
+        let result: Result<TracesResponse> = self.get("/traces", &params).await;
+        match result {
+            Ok(_) => Ok(true),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,0 +1,253 @@
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use dialoguer::{Input, Password};
+
+use crate::client::LangfuseClient;
+use crate::config::Config;
+
+#[derive(Debug, Subcommand)]
+pub enum ConfigCommands {
+    /// Interactive configuration wizard
+    Setup {
+        /// Run in non-interactive mode using environment variables
+        #[arg(long)]
+        non_interactive: bool,
+    },
+
+    /// Set configuration for a profile
+    Set {
+        /// Profile name
+        #[arg(short, long, default_value = "default")]
+        profile: String,
+
+        /// Langfuse public key
+        #[arg(long, env = "LANGFUSE_PUBLIC_KEY")]
+        public_key: String,
+
+        /// Langfuse secret key
+        #[arg(long, env = "LANGFUSE_SECRET_KEY")]
+        secret_key: String,
+
+        /// Langfuse host URL
+        #[arg(long, env = "LANGFUSE_HOST")]
+        host: Option<String>,
+    },
+
+    /// Show configuration for a profile
+    Show {
+        /// Profile name
+        #[arg(short, long, default_value = "default")]
+        profile: String,
+    },
+
+    /// List all configured profiles
+    List,
+}
+
+impl ConfigCommands {
+    pub async fn execute(&self) -> Result<()> {
+        match self {
+            ConfigCommands::Setup { non_interactive } => {
+                if *non_interactive {
+                    self.setup_non_interactive().await
+                } else {
+                    self.setup_interactive().await
+                }
+            }
+            ConfigCommands::Set {
+                profile,
+                public_key,
+                secret_key,
+                host,
+            } => self.set_config(profile, public_key, secret_key, host.as_deref()).await,
+            ConfigCommands::Show { profile } => self.show_config(profile),
+            ConfigCommands::List => self.list_profiles(),
+        }
+    }
+
+    async fn setup_interactive(&self) -> Result<()> {
+        println!("Langfuse CLI Configuration Setup");
+        println!("=================================\n");
+
+        let profile: String = Input::new()
+            .with_prompt("Profile name")
+            .default("default".to_string())
+            .interact_text()?;
+
+        let public_key: String = Input::new()
+            .with_prompt("Public key")
+            .interact_text()?;
+
+        let secret_key: String = Password::new()
+            .with_prompt("Secret key")
+            .interact()?;
+
+        let host: String = Input::new()
+            .with_prompt("Host URL")
+            .default("https://cloud.langfuse.com".to_string())
+            .interact_text()?;
+
+        // Test connection
+        println!("\nTesting connection...");
+        let config = Config::load(
+            Some(&profile),
+            Some(&public_key),
+            Some(&secret_key),
+            Some(&host),
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+        )?;
+
+        let client = LangfuseClient::new(&config)?;
+        match client.test_connection().await {
+            Ok(_) => {
+                println!("Connection successful!");
+
+                // Save configuration
+                Config::set_profile(&profile, &public_key, &secret_key, Some(&host))?;
+                println!("\nConfiguration saved to profile '{}'", profile);
+
+                if let Some(path) = Config::config_path() {
+                    println!("Config file: {:?}", path);
+                }
+
+                Ok(())
+            }
+            Err(e) => {
+                eprintln!("Connection failed: {}", e);
+                Err(e)
+            }
+        }
+    }
+
+    async fn setup_non_interactive(&self) -> Result<()> {
+        let profile = std::env::var("LANGFUSE_PROFILE").unwrap_or_else(|_| "default".to_string());
+        let public_key =
+            std::env::var("LANGFUSE_PUBLIC_KEY").context("LANGFUSE_PUBLIC_KEY not set")?;
+        let secret_key =
+            std::env::var("LANGFUSE_SECRET_KEY").context("LANGFUSE_SECRET_KEY not set")?;
+        let host = std::env::var("LANGFUSE_HOST")
+            .unwrap_or_else(|_| "https://cloud.langfuse.com".to_string());
+
+        // Test connection
+        eprintln!("Testing connection...");
+        let config = Config::load(
+            Some(&profile),
+            Some(&public_key),
+            Some(&secret_key),
+            Some(&host),
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+        )?;
+
+        let client = LangfuseClient::new(&config)?;
+        match client.test_connection().await {
+            Ok(_) => {
+                eprintln!("Connection successful!");
+
+                // Save configuration
+                Config::set_profile(&profile, &public_key, &secret_key, Some(&host))?;
+                eprintln!("Configuration saved to profile '{}'", profile);
+
+                Ok(())
+            }
+            Err(e) => {
+                eprintln!("Connection failed: {}", e);
+                Err(e)
+            }
+        }
+    }
+
+    async fn set_config(
+        &self,
+        profile: &str,
+        public_key: &str,
+        secret_key: &str,
+        host: Option<&str>,
+    ) -> Result<()> {
+        // Test connection before saving
+        let test_config = Config::load(
+            Some(profile),
+            Some(public_key),
+            Some(secret_key),
+            host,
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+        )?;
+
+        let client = LangfuseClient::new(&test_config)?;
+        match client.test_connection().await {
+            Ok(_) => {
+                Config::set_profile(profile, public_key, secret_key, host)?;
+                println!("Configuration saved to profile '{}'", profile);
+                Ok(())
+            }
+            Err(e) => {
+                eprintln!("Connection test failed: {}", e);
+                Err(e)
+            }
+        }
+    }
+
+    fn show_config(&self, profile_name: &str) -> Result<()> {
+        match Config::get_profile(profile_name)? {
+            Some(profile) => {
+                println!("Profile: {}", profile_name);
+                println!("─────────────────────────────────");
+
+                if let Some(pk) = &profile.public_key {
+                    println!("Public Key: {}", Config::mask_key(pk));
+                } else {
+                    println!("Public Key: (not set)");
+                }
+
+                if let Some(sk) = &profile.secret_key {
+                    println!("Secret Key: {}", Config::mask_key(sk));
+                } else {
+                    println!("Secret Key: (not set)");
+                }
+
+                if let Some(host) = &profile.host {
+                    println!("Host: {}", host);
+                } else {
+                    println!("Host: (default: https://cloud.langfuse.com)");
+                }
+
+                Ok(())
+            }
+            None => {
+                eprintln!("Profile '{}' not found", profile_name);
+                std::process::exit(1);
+            }
+        }
+    }
+
+    fn list_profiles(&self) -> Result<()> {
+        let profiles = Config::list_profiles()?;
+
+        if profiles.is_empty() {
+            println!("No profiles configured.");
+            println!("Run 'lf config setup' to create a profile.");
+        } else {
+            println!("Configured profiles:");
+            println!("─────────────────────");
+            for profile in profiles {
+                println!("  - {}", profile);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/commands/metrics.rs
+++ b/src/commands/metrics.rs
@@ -1,0 +1,142 @@
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::client::LangfuseClient;
+use crate::commands::{build_config, format_and_output};
+use crate::types::{Aggregation, Measure, MetricsView, OutputFormat, TimeGranularity};
+
+#[derive(Debug, Subcommand)]
+pub enum MetricsCommands {
+    /// Query metrics with aggregations
+    Query {
+        /// View to query (traces or observations)
+        #[arg(long, value_enum)]
+        view: MetricsView,
+
+        /// Measure to aggregate
+        #[arg(long, value_enum)]
+        measure: Measure,
+
+        /// Aggregation function
+        #[arg(long, value_enum)]
+        aggregation: Aggregation,
+
+        /// Dimensions for grouping (can be specified multiple times)
+        #[arg(short, long)]
+        dimensions: Option<Vec<String>>,
+
+        /// Filter from timestamp (ISO 8601 format)
+        #[arg(long)]
+        from: Option<String>,
+
+        /// Filter to timestamp (ISO 8601 format)
+        #[arg(long)]
+        to: Option<String>,
+
+        /// Time granularity for bucketing
+        #[arg(long, value_enum)]
+        granularity: Option<TimeGranularity>,
+
+        /// Maximum number of results
+        #[arg(short, long)]
+        limit: Option<u32>,
+
+        /// Output format
+        #[arg(short, long, value_enum)]
+        format: Option<OutputFormat>,
+
+        /// Output file path
+        #[arg(short, long)]
+        output: Option<String>,
+
+        /// Profile name
+        #[arg(long)]
+        profile: Option<String>,
+
+        /// Langfuse public key
+        #[arg(long, env = "LANGFUSE_PUBLIC_KEY")]
+        public_key: Option<String>,
+
+        /// Langfuse secret key
+        #[arg(long, env = "LANGFUSE_SECRET_KEY")]
+        secret_key: Option<String>,
+
+        /// Langfuse host URL
+        #[arg(long, env = "LANGFUSE_HOST")]
+        host: Option<String>,
+
+        /// Verbose output
+        #[arg(short, long)]
+        verbose: bool,
+    },
+}
+
+impl MetricsCommands {
+    pub async fn execute(&self) -> Result<()> {
+        match self {
+            MetricsCommands::Query {
+                view,
+                measure,
+                aggregation,
+                dimensions,
+                from,
+                to,
+                granularity,
+                limit,
+                format,
+                output,
+                profile,
+                public_key,
+                secret_key,
+                host,
+                verbose,
+            } => {
+                let config = build_config(
+                    profile.as_deref(),
+                    public_key.as_deref(),
+                    secret_key.as_deref(),
+                    host.as_deref(),
+                    *format,
+                    None,
+                    None,
+                    output.as_deref(),
+                    *verbose,
+                    false,
+                )?;
+
+                if !config.is_valid() {
+                    eprintln!("Error: Missing credentials. Run 'lf config setup' or set environment variables.");
+                    std::process::exit(1);
+                }
+
+                let client = LangfuseClient::new(&config)?;
+
+                // Convert view to API string
+                let view_str = match view {
+                    MetricsView::Traces => "traces",
+                    MetricsView::Observations => "observations",
+                };
+
+                let result = client
+                    .query_metrics(
+                        view_str,
+                        measure.to_api_string(),
+                        aggregation.to_api_string(),
+                        dimensions.as_deref(),
+                        from.as_deref(),
+                        to.as_deref(),
+                        granularity.as_ref().map(|g| g.to_api_string()),
+                        *limit,
+                    )
+                    .await?;
+
+                format_and_output(
+                    &result.data,
+                    format.unwrap_or(OutputFormat::Table),
+                    output.as_deref(),
+                    *verbose,
+                )
+            }
+        }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,55 @@
+pub mod config;
+pub mod traces;
+pub mod sessions;
+pub mod observations;
+pub mod scores;
+pub mod metrics;
+
+use anyhow::Result;
+use std::fs;
+
+use crate::config::Config;
+use crate::formatters::format_output;
+use crate::types::OutputFormat;
+
+/// Output result to stdout or file
+pub fn output_result(content: &str, output_path: Option<&str>, verbose: bool) -> Result<()> {
+    if let Some(path) = output_path {
+        fs::write(path, content)?;
+        if verbose {
+            eprintln!("Output written to: {}", path);
+        }
+    } else {
+        println!("{}", content);
+    }
+    Ok(())
+}
+
+/// Format and output data
+pub fn format_and_output<T: serde::Serialize>(
+    data: &T,
+    format: OutputFormat,
+    output_path: Option<&str>,
+    verbose: bool,
+) -> Result<()> {
+    let formatted = format_output(data, format)?;
+    output_result(&formatted, output_path, verbose)
+}
+
+/// Helper to build config from CLI args
+pub fn build_config(
+    profile: Option<&str>,
+    public_key: Option<&str>,
+    secret_key: Option<&str>,
+    host: Option<&str>,
+    format: Option<OutputFormat>,
+    limit: Option<u32>,
+    page: Option<u32>,
+    output: Option<&str>,
+    verbose: bool,
+    no_color: bool,
+) -> Result<Config> {
+    Config::load(
+        profile, public_key, secret_key, host, format, limit, page, output, verbose, no_color,
+    )
+}

--- a/src/commands/observations.rs
+++ b/src/commands/observations.rs
@@ -1,0 +1,212 @@
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::client::LangfuseClient;
+use crate::commands::{build_config, format_and_output};
+use crate::types::{ObservationType, OutputFormat};
+
+#[derive(Debug, Subcommand)]
+pub enum ObservationsCommands {
+    /// List observations with optional filters
+    List {
+        /// Filter by trace ID
+        #[arg(short, long)]
+        trace_id: Option<String>,
+
+        /// Filter by observation name
+        #[arg(short, long)]
+        name: Option<String>,
+
+        /// Filter by observation type
+        #[arg(long, value_enum)]
+        r#type: Option<ObservationType>,
+
+        /// Filter by user ID
+        #[arg(short, long)]
+        user_id: Option<String>,
+
+        /// Filter from start time (ISO 8601 format)
+        #[arg(long)]
+        from: Option<String>,
+
+        /// Filter to start time (ISO 8601 format)
+        #[arg(long)]
+        to: Option<String>,
+
+        /// Maximum number of results
+        #[arg(short, long, default_value = "50")]
+        limit: u32,
+
+        /// Page number
+        #[arg(short, long, default_value = "1")]
+        page: u32,
+
+        /// Output format
+        #[arg(short, long, value_enum)]
+        format: Option<OutputFormat>,
+
+        /// Output file path
+        #[arg(short, long)]
+        output: Option<String>,
+
+        /// Profile name
+        #[arg(long)]
+        profile: Option<String>,
+
+        /// Langfuse public key
+        #[arg(long, env = "LANGFUSE_PUBLIC_KEY")]
+        public_key: Option<String>,
+
+        /// Langfuse secret key
+        #[arg(long, env = "LANGFUSE_SECRET_KEY")]
+        secret_key: Option<String>,
+
+        /// Langfuse host URL
+        #[arg(long, env = "LANGFUSE_HOST")]
+        host: Option<String>,
+
+        /// Verbose output
+        #[arg(short, long)]
+        verbose: bool,
+    },
+
+    /// Get a specific observation by ID
+    Get {
+        /// Observation ID
+        id: String,
+
+        /// Output format
+        #[arg(short, long, value_enum)]
+        format: Option<OutputFormat>,
+
+        /// Output file path
+        #[arg(short, long)]
+        output: Option<String>,
+
+        /// Profile name
+        #[arg(long)]
+        profile: Option<String>,
+
+        /// Langfuse public key
+        #[arg(long, env = "LANGFUSE_PUBLIC_KEY")]
+        public_key: Option<String>,
+
+        /// Langfuse secret key
+        #[arg(long, env = "LANGFUSE_SECRET_KEY")]
+        secret_key: Option<String>,
+
+        /// Langfuse host URL
+        #[arg(long, env = "LANGFUSE_HOST")]
+        host: Option<String>,
+
+        /// Verbose output
+        #[arg(short, long)]
+        verbose: bool,
+    },
+}
+
+impl ObservationsCommands {
+    pub async fn execute(&self) -> Result<()> {
+        match self {
+            ObservationsCommands::List {
+                trace_id,
+                name,
+                r#type,
+                user_id,
+                from,
+                to,
+                limit,
+                page,
+                format,
+                output,
+                profile,
+                public_key,
+                secret_key,
+                host,
+                verbose,
+            } => {
+                let config = build_config(
+                    profile.as_deref(),
+                    public_key.as_deref(),
+                    secret_key.as_deref(),
+                    host.as_deref(),
+                    *format,
+                    Some(*limit),
+                    Some(*page),
+                    output.as_deref(),
+                    *verbose,
+                    false,
+                )?;
+
+                if !config.is_valid() {
+                    eprintln!("Error: Missing credentials. Run 'lf config setup' or set environment variables.");
+                    std::process::exit(1);
+                }
+
+                let client = LangfuseClient::new(&config)?;
+
+                let obs_type_str = r#type.as_ref().map(|t| t.to_api_string());
+
+                let observations = client
+                    .list_observations(
+                        trace_id.as_deref(),
+                        name.as_deref(),
+                        obs_type_str,
+                        user_id.as_deref(),
+                        from.as_deref(),
+                        to.as_deref(),
+                        *limit,
+                        *page,
+                    )
+                    .await?;
+
+                format_and_output(
+                    &observations,
+                    format.unwrap_or(OutputFormat::Table),
+                    output.as_deref(),
+                    *verbose,
+                )
+            }
+
+            ObservationsCommands::Get {
+                id,
+                format,
+                output,
+                profile,
+                public_key,
+                secret_key,
+                host,
+                verbose,
+            } => {
+                let config = build_config(
+                    profile.as_deref(),
+                    public_key.as_deref(),
+                    secret_key.as_deref(),
+                    host.as_deref(),
+                    *format,
+                    None,
+                    None,
+                    output.as_deref(),
+                    *verbose,
+                    false,
+                )?;
+
+                if !config.is_valid() {
+                    eprintln!("Error: Missing credentials. Run 'lf config setup' or set environment variables.");
+                    std::process::exit(1);
+                }
+
+                let client = LangfuseClient::new(&config)?;
+
+                let observation = client.get_observation(id).await?;
+
+                format_and_output(
+                    &observation,
+                    format.unwrap_or(OutputFormat::Table),
+                    output.as_deref(),
+                    *verbose,
+                )
+            }
+        }
+    }
+}

--- a/src/commands/scores.rs
+++ b/src/commands/scores.rs
@@ -1,0 +1,192 @@
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::client::LangfuseClient;
+use crate::commands::{build_config, format_and_output};
+use crate::types::OutputFormat;
+
+#[derive(Debug, Subcommand)]
+pub enum ScoresCommands {
+    /// List scores with optional filters
+    List {
+        /// Filter by score name
+        #[arg(short, long)]
+        name: Option<String>,
+
+        /// Filter from timestamp (ISO 8601 format)
+        #[arg(long)]
+        from: Option<String>,
+
+        /// Filter to timestamp (ISO 8601 format)
+        #[arg(long)]
+        to: Option<String>,
+
+        /// Maximum number of results
+        #[arg(short, long, default_value = "50")]
+        limit: u32,
+
+        /// Page number
+        #[arg(short, long, default_value = "1")]
+        page: u32,
+
+        /// Output format
+        #[arg(short, long, value_enum)]
+        format: Option<OutputFormat>,
+
+        /// Output file path
+        #[arg(short, long)]
+        output: Option<String>,
+
+        /// Profile name
+        #[arg(long)]
+        profile: Option<String>,
+
+        /// Langfuse public key
+        #[arg(long, env = "LANGFUSE_PUBLIC_KEY")]
+        public_key: Option<String>,
+
+        /// Langfuse secret key
+        #[arg(long, env = "LANGFUSE_SECRET_KEY")]
+        secret_key: Option<String>,
+
+        /// Langfuse host URL
+        #[arg(long, env = "LANGFUSE_HOST")]
+        host: Option<String>,
+
+        /// Verbose output
+        #[arg(short, long)]
+        verbose: bool,
+    },
+
+    /// Get a specific score by ID
+    Get {
+        /// Score ID
+        id: String,
+
+        /// Output format
+        #[arg(short, long, value_enum)]
+        format: Option<OutputFormat>,
+
+        /// Output file path
+        #[arg(short, long)]
+        output: Option<String>,
+
+        /// Profile name
+        #[arg(long)]
+        profile: Option<String>,
+
+        /// Langfuse public key
+        #[arg(long, env = "LANGFUSE_PUBLIC_KEY")]
+        public_key: Option<String>,
+
+        /// Langfuse secret key
+        #[arg(long, env = "LANGFUSE_SECRET_KEY")]
+        secret_key: Option<String>,
+
+        /// Langfuse host URL
+        #[arg(long, env = "LANGFUSE_HOST")]
+        host: Option<String>,
+
+        /// Verbose output
+        #[arg(short, long)]
+        verbose: bool,
+    },
+}
+
+impl ScoresCommands {
+    pub async fn execute(&self) -> Result<()> {
+        match self {
+            ScoresCommands::List {
+                name,
+                from,
+                to,
+                limit,
+                page,
+                format,
+                output,
+                profile,
+                public_key,
+                secret_key,
+                host,
+                verbose,
+            } => {
+                let config = build_config(
+                    profile.as_deref(),
+                    public_key.as_deref(),
+                    secret_key.as_deref(),
+                    host.as_deref(),
+                    *format,
+                    Some(*limit),
+                    Some(*page),
+                    output.as_deref(),
+                    *verbose,
+                    false,
+                )?;
+
+                if !config.is_valid() {
+                    eprintln!("Error: Missing credentials. Run 'lf config setup' or set environment variables.");
+                    std::process::exit(1);
+                }
+
+                let client = LangfuseClient::new(&config)?;
+
+                let scores = client
+                    .list_scores(
+                        name.as_deref(),
+                        from.as_deref(),
+                        to.as_deref(),
+                        *limit,
+                        *page,
+                    )
+                    .await?;
+
+                format_and_output(
+                    &scores,
+                    format.unwrap_or(OutputFormat::Table),
+                    output.as_deref(),
+                    *verbose,
+                )
+            }
+
+            ScoresCommands::Get {
+                id,
+                format,
+                output,
+                profile,
+                public_key,
+                secret_key,
+                host,
+                verbose,
+            } => {
+                let config = build_config(
+                    profile.as_deref(),
+                    public_key.as_deref(),
+                    secret_key.as_deref(),
+                    host.as_deref(),
+                    *format,
+                    None,
+                    None,
+                    output.as_deref(),
+                    *verbose,
+                    false,
+                )?;
+
+                if !config.is_valid() {
+                    eprintln!("Error: Missing credentials. Run 'lf config setup' or set environment variables.");
+                    std::process::exit(1);
+                }
+
+                let client = LangfuseClient::new(&config)?;
+
+                let score = client.get_score(id).await?;
+
+                format_and_output(
+                    &score,
+                    format.unwrap_or(OutputFormat::Table),
+                    output.as_deref(),
+                    *verbose,
+                )
+            }
+        }
+    }
+}

--- a/src/commands/sessions.rs
+++ b/src/commands/sessions.rs
@@ -1,0 +1,203 @@
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::client::LangfuseClient;
+use crate::commands::{build_config, format_and_output};
+use crate::types::OutputFormat;
+
+#[derive(Debug, Subcommand)]
+pub enum SessionsCommands {
+    /// List sessions with optional filters
+    List {
+        /// Filter from timestamp (ISO 8601 format)
+        #[arg(long)]
+        from: Option<String>,
+
+        /// Filter to timestamp (ISO 8601 format)
+        #[arg(long)]
+        to: Option<String>,
+
+        /// Maximum number of results
+        #[arg(short, long, default_value = "50")]
+        limit: u32,
+
+        /// Page number
+        #[arg(short, long, default_value = "1")]
+        page: u32,
+
+        /// Output format
+        #[arg(short, long, value_enum)]
+        format: Option<OutputFormat>,
+
+        /// Output file path
+        #[arg(short, long)]
+        output: Option<String>,
+
+        /// Profile name
+        #[arg(long)]
+        profile: Option<String>,
+
+        /// Langfuse public key
+        #[arg(long, env = "LANGFUSE_PUBLIC_KEY")]
+        public_key: Option<String>,
+
+        /// Langfuse secret key
+        #[arg(long, env = "LANGFUSE_SECRET_KEY")]
+        secret_key: Option<String>,
+
+        /// Langfuse host URL
+        #[arg(long, env = "LANGFUSE_HOST")]
+        host: Option<String>,
+
+        /// Verbose output
+        #[arg(short, long)]
+        verbose: bool,
+    },
+
+    /// Show details of a specific session
+    Show {
+        /// Session ID
+        id: String,
+
+        /// Include associated traces
+        #[arg(long)]
+        with_traces: bool,
+
+        /// Output format
+        #[arg(short, long, value_enum)]
+        format: Option<OutputFormat>,
+
+        /// Output file path
+        #[arg(short, long)]
+        output: Option<String>,
+
+        /// Profile name
+        #[arg(long)]
+        profile: Option<String>,
+
+        /// Langfuse public key
+        #[arg(long, env = "LANGFUSE_PUBLIC_KEY")]
+        public_key: Option<String>,
+
+        /// Langfuse secret key
+        #[arg(long, env = "LANGFUSE_SECRET_KEY")]
+        secret_key: Option<String>,
+
+        /// Langfuse host URL
+        #[arg(long, env = "LANGFUSE_HOST")]
+        host: Option<String>,
+
+        /// Verbose output
+        #[arg(short, long)]
+        verbose: bool,
+    },
+}
+
+impl SessionsCommands {
+    pub async fn execute(&self) -> Result<()> {
+        match self {
+            SessionsCommands::List {
+                from,
+                to,
+                limit,
+                page,
+                format,
+                output,
+                profile,
+                public_key,
+                secret_key,
+                host,
+                verbose,
+            } => {
+                let config = build_config(
+                    profile.as_deref(),
+                    public_key.as_deref(),
+                    secret_key.as_deref(),
+                    host.as_deref(),
+                    *format,
+                    Some(*limit),
+                    Some(*page),
+                    output.as_deref(),
+                    *verbose,
+                    false,
+                )?;
+
+                if !config.is_valid() {
+                    eprintln!("Error: Missing credentials. Run 'lf config setup' or set environment variables.");
+                    std::process::exit(1);
+                }
+
+                let client = LangfuseClient::new(&config)?;
+
+                let sessions = client
+                    .list_sessions(from.as_deref(), to.as_deref(), *limit, *page)
+                    .await?;
+
+                format_and_output(
+                    &sessions,
+                    format.unwrap_or(OutputFormat::Table),
+                    output.as_deref(),
+                    *verbose,
+                )
+            }
+
+            SessionsCommands::Show {
+                id,
+                with_traces,
+                format,
+                output,
+                profile,
+                public_key,
+                secret_key,
+                host,
+                verbose,
+            } => {
+                let config = build_config(
+                    profile.as_deref(),
+                    public_key.as_deref(),
+                    secret_key.as_deref(),
+                    host.as_deref(),
+                    *format,
+                    None,
+                    None,
+                    output.as_deref(),
+                    *verbose,
+                    false,
+                )?;
+
+                if !config.is_valid() {
+                    eprintln!("Error: Missing credentials. Run 'lf config setup' or set environment variables.");
+                    std::process::exit(1);
+                }
+
+                let client = LangfuseClient::new(&config)?;
+
+                let mut session = client.get_session(id).await?;
+
+                // Fetch traces if requested
+                if *with_traces {
+                    let traces = client
+                        .list_traces(
+                            None,
+                            None,
+                            Some(id),
+                            None,
+                            None,
+                            None,
+                            100,
+                            1,
+                        )
+                        .await?;
+                    session.traces = traces;
+                }
+
+                format_and_output(
+                    &session,
+                    format.unwrap_or(OutputFormat::Table),
+                    output.as_deref(),
+                    *verbose,
+                )
+            }
+        }
+    }
+}

--- a/src/commands/traces.rs
+++ b/src/commands/traces.rs
@@ -1,0 +1,232 @@
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::client::LangfuseClient;
+use crate::commands::{build_config, format_and_output};
+use crate::types::OutputFormat;
+
+#[derive(Debug, Subcommand)]
+pub enum TracesCommands {
+    /// List traces with optional filters
+    List {
+        /// Filter by trace name
+        #[arg(short, long)]
+        name: Option<String>,
+
+        /// Filter by user ID
+        #[arg(short, long)]
+        user_id: Option<String>,
+
+        /// Filter by session ID
+        #[arg(short, long)]
+        session_id: Option<String>,
+
+        /// Filter by tags (can be specified multiple times)
+        #[arg(short, long)]
+        tags: Option<Vec<String>>,
+
+        /// Filter from timestamp (ISO 8601 format)
+        #[arg(long)]
+        from: Option<String>,
+
+        /// Filter to timestamp (ISO 8601 format)
+        #[arg(long)]
+        to: Option<String>,
+
+        /// Maximum number of results
+        #[arg(short, long, default_value = "50")]
+        limit: u32,
+
+        /// Page number
+        #[arg(short, long, default_value = "1")]
+        page: u32,
+
+        /// Output format
+        #[arg(short, long, value_enum)]
+        format: Option<OutputFormat>,
+
+        /// Output file path
+        #[arg(short, long)]
+        output: Option<String>,
+
+        /// Profile name
+        #[arg(long)]
+        profile: Option<String>,
+
+        /// Langfuse public key
+        #[arg(long, env = "LANGFUSE_PUBLIC_KEY")]
+        public_key: Option<String>,
+
+        /// Langfuse secret key
+        #[arg(long, env = "LANGFUSE_SECRET_KEY")]
+        secret_key: Option<String>,
+
+        /// Langfuse host URL
+        #[arg(long, env = "LANGFUSE_HOST")]
+        host: Option<String>,
+
+        /// Verbose output
+        #[arg(short, long)]
+        verbose: bool,
+    },
+
+    /// Get a specific trace by ID
+    Get {
+        /// Trace ID
+        id: String,
+
+        /// Include observations
+        #[arg(long)]
+        with_observations: bool,
+
+        /// Output format
+        #[arg(short, long, value_enum)]
+        format: Option<OutputFormat>,
+
+        /// Output file path
+        #[arg(short, long)]
+        output: Option<String>,
+
+        /// Profile name
+        #[arg(long)]
+        profile: Option<String>,
+
+        /// Langfuse public key
+        #[arg(long, env = "LANGFUSE_PUBLIC_KEY")]
+        public_key: Option<String>,
+
+        /// Langfuse secret key
+        #[arg(long, env = "LANGFUSE_SECRET_KEY")]
+        secret_key: Option<String>,
+
+        /// Langfuse host URL
+        #[arg(long, env = "LANGFUSE_HOST")]
+        host: Option<String>,
+
+        /// Verbose output
+        #[arg(short, long)]
+        verbose: bool,
+    },
+}
+
+impl TracesCommands {
+    pub async fn execute(&self) -> Result<()> {
+        match self {
+            TracesCommands::List {
+                name,
+                user_id,
+                session_id,
+                tags,
+                from,
+                to,
+                limit,
+                page,
+                format,
+                output,
+                profile,
+                public_key,
+                secret_key,
+                host,
+                verbose,
+            } => {
+                let config = build_config(
+                    profile.as_deref(),
+                    public_key.as_deref(),
+                    secret_key.as_deref(),
+                    host.as_deref(),
+                    *format,
+                    Some(*limit),
+                    Some(*page),
+                    output.as_deref(),
+                    *verbose,
+                    false,
+                )?;
+
+                if !config.is_valid() {
+                    eprintln!("Error: Missing credentials. Run 'lf config setup' or set environment variables.");
+                    std::process::exit(1);
+                }
+
+                let client = LangfuseClient::new(&config)?;
+
+                let traces = client
+                    .list_traces(
+                        name.as_deref(),
+                        user_id.as_deref(),
+                        session_id.as_deref(),
+                        tags.as_deref(),
+                        from.as_deref(),
+                        to.as_deref(),
+                        *limit,
+                        *page,
+                    )
+                    .await?;
+
+                format_and_output(
+                    &traces,
+                    format.unwrap_or(OutputFormat::Table),
+                    output.as_deref(),
+                    *verbose,
+                )
+            }
+
+            TracesCommands::Get {
+                id,
+                with_observations,
+                format,
+                output,
+                profile,
+                public_key,
+                secret_key,
+                host,
+                verbose,
+            } => {
+                let config = build_config(
+                    profile.as_deref(),
+                    public_key.as_deref(),
+                    secret_key.as_deref(),
+                    host.as_deref(),
+                    *format,
+                    None,
+                    None,
+                    output.as_deref(),
+                    *verbose,
+                    false,
+                )?;
+
+                if !config.is_valid() {
+                    eprintln!("Error: Missing credentials. Run 'lf config setup' or set environment variables.");
+                    std::process::exit(1);
+                }
+
+                let client = LangfuseClient::new(&config)?;
+
+                let mut trace = client.get_trace(id).await?;
+
+                // Fetch observations if requested
+                if *with_observations {
+                    let observations = client
+                        .list_observations(
+                            Some(id),
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            100,
+                            1,
+                        )
+                        .await?;
+                    trace.observations = observations;
+                }
+
+                format_and_output(
+                    &trace,
+                    format.unwrap_or(OutputFormat::Table),
+                    output.as_deref(),
+                    *verbose,
+                )
+            }
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,220 @@
+use anyhow::{Context, Result};
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use crate::types::OutputFormat;
+
+const DEFAULT_HOST: &str = "https://cloud.langfuse.com";
+const DEFAULT_PROFILE: &str = "default";
+const DEFAULT_LIMIT: u32 = 50;
+
+/// Profile configuration stored in config file
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Profile {
+    pub public_key: Option<String>,
+    pub secret_key: Option<String>,
+    pub host: Option<String>,
+}
+
+/// Configuration file structure
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ConfigFile {
+    #[serde(default)]
+    pub profiles: HashMap<String, Profile>,
+}
+
+/// Runtime configuration with resolved values
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub public_key: Option<String>,
+    pub secret_key: Option<String>,
+    pub host: String,
+    pub profile: String,
+    pub format: OutputFormat,
+    pub limit: u32,
+    pub page: u32,
+    pub output: Option<String>,
+    pub verbose: bool,
+    pub no_color: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            public_key: None,
+            secret_key: None,
+            host: DEFAULT_HOST.to_string(),
+            profile: DEFAULT_PROFILE.to_string(),
+            format: OutputFormat::Table,
+            limit: DEFAULT_LIMIT,
+            page: 1,
+            output: None,
+            verbose: false,
+            no_color: false,
+        }
+    }
+}
+
+impl Config {
+    /// Get the config file path
+    pub fn config_path() -> Option<PathBuf> {
+        if let Some(proj_dirs) = ProjectDirs::from("", "", "langfuse") {
+            let config_dir = proj_dirs.config_dir();
+            Some(config_dir.join("config.yml"))
+        } else {
+            // Fallback to ~/.langfuse/config.yml
+            dirs::home_dir().map(|home| home.join(".langfuse").join("config.yml"))
+        }
+    }
+
+    /// Load configuration file
+    pub fn load_config_file() -> Result<ConfigFile> {
+        let path = Self::config_path();
+
+        if let Some(path) = path {
+            if path.exists() {
+                let contents = fs::read_to_string(&path)
+                    .with_context(|| format!("Failed to read config file: {:?}", path))?;
+                let config: ConfigFile = serde_yaml::from_str(&contents)
+                    .with_context(|| "Failed to parse config file")?;
+                return Ok(config);
+            }
+        }
+
+        Ok(ConfigFile::default())
+    }
+
+    /// Save configuration file
+    pub fn save_config_file(config_file: &ConfigFile) -> Result<()> {
+        let path = Self::config_path()
+            .ok_or_else(|| anyhow::anyhow!("Could not determine config file path"))?;
+
+        // Create directory if it doesn't exist
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create config directory: {:?}", parent))?;
+        }
+
+        let contents = serde_yaml::to_string(config_file)
+            .with_context(|| "Failed to serialize config")?;
+
+        fs::write(&path, contents)
+            .with_context(|| format!("Failed to write config file: {:?}", path))?;
+
+        // Set restrictive permissions on Unix systems
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&path)?.permissions();
+            perms.set_mode(0o600);
+            fs::set_permissions(&path, perms)?;
+        }
+
+        Ok(())
+    }
+
+    /// Load configuration with priority: CLI options > env vars > config file > defaults
+    pub fn load(
+        profile: Option<&str>,
+        public_key: Option<&str>,
+        secret_key: Option<&str>,
+        host: Option<&str>,
+        format: Option<OutputFormat>,
+        limit: Option<u32>,
+        page: Option<u32>,
+        output: Option<&str>,
+        verbose: bool,
+        no_color: bool,
+    ) -> Result<Self> {
+        let profile_name = profile
+            .map(|s| s.to_string())
+            .or_else(|| std::env::var("LANGFUSE_PROFILE").ok())
+            .unwrap_or_else(|| DEFAULT_PROFILE.to_string());
+
+        // Load config file
+        let config_file = Self::load_config_file().unwrap_or_default();
+        let file_profile = config_file.profiles.get(&profile_name);
+
+        // Resolve public key: CLI > env > config file
+        let resolved_public_key = public_key
+            .map(|s| s.to_string())
+            .or_else(|| std::env::var("LANGFUSE_PUBLIC_KEY").ok())
+            .or_else(|| file_profile.and_then(|p| p.public_key.clone()));
+
+        // Resolve secret key: CLI > env > config file
+        let resolved_secret_key = secret_key
+            .map(|s| s.to_string())
+            .or_else(|| std::env::var("LANGFUSE_SECRET_KEY").ok())
+            .or_else(|| file_profile.and_then(|p| p.secret_key.clone()));
+
+        // Resolve host: CLI > env > config file > default
+        let resolved_host = host
+            .map(|s| s.to_string())
+            .or_else(|| std::env::var("LANGFUSE_HOST").ok())
+            .or_else(|| file_profile.and_then(|p| p.host.clone()))
+            .unwrap_or_else(|| DEFAULT_HOST.to_string());
+
+        Ok(Self {
+            public_key: resolved_public_key,
+            secret_key: resolved_secret_key,
+            host: resolved_host,
+            profile: profile_name,
+            format: format.unwrap_or(OutputFormat::Table),
+            limit: limit.unwrap_or(DEFAULT_LIMIT),
+            page: page.unwrap_or(1),
+            output: output.map(|s| s.to_string()),
+            verbose,
+            no_color,
+        })
+    }
+
+    /// Check if configuration has required credentials
+    pub fn is_valid(&self) -> bool {
+        self.public_key.is_some() && self.secret_key.is_some() && !self.host.is_empty()
+    }
+
+    /// Set a profile in the config file
+    pub fn set_profile(
+        profile_name: &str,
+        public_key: &str,
+        secret_key: &str,
+        host: Option<&str>,
+    ) -> Result<()> {
+        let mut config_file = Self::load_config_file().unwrap_or_default();
+
+        config_file.profiles.insert(
+            profile_name.to_string(),
+            Profile {
+                public_key: Some(public_key.to_string()),
+                secret_key: Some(secret_key.to_string()),
+                host: host.map(|s| s.to_string()),
+            },
+        );
+
+        Self::save_config_file(&config_file)
+    }
+
+    /// Get a profile from the config file
+    pub fn get_profile(profile_name: &str) -> Result<Option<Profile>> {
+        let config_file = Self::load_config_file()?;
+        Ok(config_file.profiles.get(profile_name).cloned())
+    }
+
+    /// List all profiles
+    pub fn list_profiles() -> Result<Vec<String>> {
+        let config_file = Self::load_config_file()?;
+        Ok(config_file.profiles.keys().cloned().collect())
+    }
+
+    /// Mask a key for display (show first 8 chars + asterisks)
+    pub fn mask_key(key: &str) -> String {
+        if key.len() <= 8 {
+            "*".repeat(key.len())
+        } else {
+            format!("{}********", &key[..8])
+        }
+    }
+}

--- a/src/formatters/csv_formatter.rs
+++ b/src/formatters/csv_formatter.rs
@@ -1,0 +1,74 @@
+use anyhow::Result;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::BTreeSet;
+
+pub struct CsvFormatter;
+
+impl CsvFormatter {
+    pub fn format<T: Serialize>(data: &T) -> Result<String> {
+        let value = serde_json::to_value(data)?;
+
+        match &value {
+            Value::Array(arr) if arr.is_empty() => Ok("No data to display".to_string()),
+            Value::Null => Ok("No data to display".to_string()),
+            Value::Array(arr) => Self::format_array(arr),
+            Value::Object(_) => Self::format_array(&[value]),
+            _ => Ok(value.to_string()),
+        }
+    }
+
+    fn format_array(arr: &[Value]) -> Result<String> {
+        if arr.is_empty() {
+            return Ok("No data to display".to_string());
+        }
+
+        // Collect all unique keys across all objects
+        let mut headers: BTreeSet<String> = BTreeSet::new();
+        for item in arr {
+            if let Value::Object(obj) = item {
+                for key in obj.keys() {
+                    headers.insert(key.clone());
+                }
+            }
+        }
+
+        let headers_vec: Vec<String> = headers.into_iter().collect();
+
+        let mut wtr = csv::Writer::from_writer(vec![]);
+
+        // Write header row
+        wtr.write_record(&headers_vec)?;
+
+        // Write data rows
+        for item in arr {
+            let row: Vec<String> = headers_vec
+                .iter()
+                .map(|key| {
+                    if let Value::Object(obj) = item {
+                        Self::format_value(obj.get(key))
+                    } else {
+                        String::new()
+                    }
+                })
+                .collect();
+            wtr.write_record(&row)?;
+        }
+
+        wtr.flush()?;
+        let data = wtr.into_inner()?;
+        Ok(String::from_utf8(data)?)
+    }
+
+    fn format_value(value: Option<&Value>) -> String {
+        match value {
+            None | Some(Value::Null) => String::new(),
+            Some(Value::String(s)) => s.clone(),
+            Some(Value::Number(n)) => n.to_string(),
+            Some(Value::Bool(b)) => b.to_string(),
+            Some(Value::Array(_)) | Some(Value::Object(_)) => {
+                serde_json::to_string(value.unwrap()).unwrap_or_default()
+            }
+        }
+    }
+}

--- a/src/formatters/json.rs
+++ b/src/formatters/json.rs
@@ -1,0 +1,10 @@
+use anyhow::Result;
+use serde::Serialize;
+
+pub struct JsonFormatter;
+
+impl JsonFormatter {
+    pub fn format<T: Serialize>(data: &T) -> Result<String> {
+        Ok(serde_json::to_string_pretty(data)?)
+    }
+}

--- a/src/formatters/markdown.rs
+++ b/src/formatters/markdown.rs
@@ -1,0 +1,86 @@
+use anyhow::Result;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::BTreeSet;
+
+pub struct MarkdownFormatter;
+
+impl MarkdownFormatter {
+    pub fn format<T: Serialize>(data: &T) -> Result<String> {
+        let value = serde_json::to_value(data)?;
+
+        match &value {
+            Value::Array(arr) if arr.is_empty() => Ok("No data to display".to_string()),
+            Value::Null => Ok("No data to display".to_string()),
+            Value::Array(arr) => Self::format_array(arr),
+            Value::Object(_) => Self::format_array(&[value]),
+            _ => Ok(value.to_string()),
+        }
+    }
+
+    fn format_array(arr: &[Value]) -> Result<String> {
+        if arr.is_empty() {
+            return Ok("No data to display".to_string());
+        }
+
+        // Collect all unique keys across all objects
+        let mut headers: BTreeSet<String> = BTreeSet::new();
+        for item in arr {
+            if let Value::Object(obj) = item {
+                for key in obj.keys() {
+                    headers.insert(key.clone());
+                }
+            }
+        }
+
+        let headers_vec: Vec<String> = headers.into_iter().collect();
+
+        let mut output = String::new();
+
+        // Header row
+        output.push('|');
+        for header in &headers_vec {
+            output.push_str(&format!(" {} |", header));
+        }
+        output.push('\n');
+
+        // Separator row
+        output.push('|');
+        for _ in &headers_vec {
+            output.push_str(" --- |");
+        }
+        output.push('\n');
+
+        // Data rows
+        for item in arr {
+            output.push('|');
+            for key in &headers_vec {
+                let value = if let Value::Object(obj) = item {
+                    Self::format_value(obj.get(key))
+                } else {
+                    String::new()
+                };
+                output.push_str(&format!(" {} |", Self::escape_pipes(&value)));
+            }
+            output.push('\n');
+        }
+
+        Ok(output)
+    }
+
+    fn format_value(value: Option<&Value>) -> String {
+        match value {
+            None | Some(Value::Null) => String::new(),
+            Some(Value::String(s)) => s.clone(),
+            Some(Value::Number(n)) => n.to_string(),
+            Some(Value::Bool(b)) => b.to_string(),
+            Some(Value::Array(_)) | Some(Value::Object(_)) => {
+                serde_json::to_string(value.unwrap()).unwrap_or_default()
+            }
+        }
+    }
+
+    fn escape_pipes(s: &str) -> String {
+        s.replace('|', "\\|")
+    }
+}

--- a/src/formatters/mod.rs
+++ b/src/formatters/mod.rs
@@ -1,0 +1,24 @@
+mod table;
+mod csv_formatter;
+mod markdown;
+mod json;
+
+pub use table::TableFormatter;
+pub use csv_formatter::CsvFormatter;
+pub use markdown::MarkdownFormatter;
+pub use json::JsonFormatter;
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::types::OutputFormat;
+
+/// Format data according to the specified output format
+pub fn format_output<T: Serialize>(data: &T, format: OutputFormat) -> Result<String> {
+    match format {
+        OutputFormat::Table => TableFormatter::format(data),
+        OutputFormat::Json => JsonFormatter::format(data),
+        OutputFormat::Csv => CsvFormatter::format(data),
+        OutputFormat::Markdown => MarkdownFormatter::format(data),
+    }
+}

--- a/src/formatters/table.rs
+++ b/src/formatters/table.rs
@@ -1,0 +1,91 @@
+use anyhow::Result;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::BTreeSet;
+use tabled::{builder::Builder, settings::Style};
+
+pub struct TableFormatter;
+
+impl TableFormatter {
+    pub fn format<T: Serialize>(data: &T) -> Result<String> {
+        let value = serde_json::to_value(data)?;
+
+        match &value {
+            Value::Array(arr) if arr.is_empty() => Ok("No data to display".to_string()),
+            Value::Null => Ok("No data to display".to_string()),
+            Value::Array(arr) => Self::format_array(arr),
+            Value::Object(_) => Self::format_array(&[value]),
+            _ => Ok(value.to_string()),
+        }
+    }
+
+    fn format_array(arr: &[Value]) -> Result<String> {
+        if arr.is_empty() {
+            return Ok("No data to display".to_string());
+        }
+
+        // Collect all unique keys across all objects
+        let mut headers: BTreeSet<String> = BTreeSet::new();
+        for item in arr {
+            if let Value::Object(obj) = item {
+                for key in obj.keys() {
+                    headers.insert(key.clone());
+                }
+            }
+        }
+
+        let headers_vec: Vec<String> = headers.into_iter().collect();
+
+        let mut builder = Builder::default();
+
+        // Add header row
+        builder.push_record(headers_vec.iter().map(|s| s.as_str()));
+
+        // Add data rows
+        for item in arr {
+            let row: Vec<String> = headers_vec
+                .iter()
+                .map(|key| {
+                    if let Value::Object(obj) = item {
+                        Self::format_value(obj.get(key))
+                    } else {
+                        String::new()
+                    }
+                })
+                .collect();
+            builder.push_record(row);
+        }
+
+        let mut table = builder.build();
+        table.with(Style::rounded());
+
+        Ok(table.to_string())
+    }
+
+    fn format_value(value: Option<&Value>) -> String {
+        match value {
+            None | Some(Value::Null) => String::new(),
+            Some(Value::String(s)) => s.clone(),
+            Some(Value::Number(n)) => n.to_string(),
+            Some(Value::Bool(b)) => b.to_string(),
+            Some(Value::Array(arr)) => {
+                // Truncate long arrays
+                let s = serde_json::to_string(arr).unwrap_or_default();
+                Self::truncate_string(&s, 50)
+            }
+            Some(Value::Object(obj)) => {
+                // Truncate long objects
+                let s = serde_json::to_string(obj).unwrap_or_default();
+                Self::truncate_string(&s, 50)
+            }
+        }
+    }
+
+    fn truncate_string(s: &str, max_len: usize) -> String {
+        if s.len() <= max_len {
+            s.to_string()
+        } else {
+            format!("{}...", &s[..max_len])
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,71 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+mod client;
+mod commands;
+mod config;
+mod formatters;
+mod types;
+
+use commands::config::ConfigCommands;
+use commands::metrics::MetricsCommands;
+use commands::observations::ObservationsCommands;
+use commands::scores::ScoresCommands;
+use commands::sessions::SessionsCommands;
+use commands::traces::TracesCommands;
+
+/// Langfuse CLI - Command-line interface for Langfuse observability platform
+#[derive(Parser)]
+#[command(name = "lf")]
+#[command(author = "Langfuse CLI Contributors")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
+#[command(about = "Command-line interface for Langfuse LLM observability platform", long_about = None)]
+#[command(propagate_version = true)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Manage configuration profiles
+    #[command(subcommand)]
+    Config(ConfigCommands),
+
+    /// Query and manage traces
+    #[command(subcommand)]
+    Traces(TracesCommands),
+
+    /// Query and manage sessions
+    #[command(subcommand)]
+    Sessions(SessionsCommands),
+
+    /// Query and manage observations
+    #[command(subcommand)]
+    Observations(ObservationsCommands),
+
+    /// Query and manage scores
+    #[command(subcommand)]
+    Scores(ScoresCommands),
+
+    /// Query metrics with aggregations
+    #[command(subcommand)]
+    Metrics(MetricsCommands),
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Load .env file if present
+    let _ = dotenvy::dotenv();
+
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Config(cmd) => cmd.execute().await,
+        Commands::Traces(cmd) => cmd.execute().await,
+        Commands::Sessions(cmd) => cmd.execute().await,
+        Commands::Observations(cmd) => cmd.execute().await,
+        Commands::Scores(cmd) => cmd.execute().await,
+        Commands::Metrics(cmd) => cmd.execute().await,
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,248 @@
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Output format options
+#[derive(Debug, Clone, Copy, Default, ValueEnum, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum OutputFormat {
+    #[default]
+    Table,
+    Json,
+    Csv,
+    Markdown,
+}
+
+/// Metrics view options
+#[derive(Debug, Clone, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MetricsView {
+    Traces,
+    Observations,
+}
+
+/// Metrics measure options
+#[derive(Debug, Clone, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Measure {
+    Count,
+    Latency,
+    InputTokens,
+    OutputTokens,
+    TotalTokens,
+    InputCost,
+    OutputCost,
+    TotalCost,
+}
+
+impl Measure {
+    pub fn to_api_string(&self) -> &str {
+        match self {
+            Measure::Count => "count",
+            Measure::Latency => "latency",
+            Measure::InputTokens => "inputTokens",
+            Measure::OutputTokens => "outputTokens",
+            Measure::TotalTokens => "totalTokens",
+            Measure::InputCost => "inputCost",
+            Measure::OutputCost => "outputCost",
+            Measure::TotalCost => "totalCost",
+        }
+    }
+}
+
+/// Metrics aggregation options
+#[derive(Debug, Clone, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Aggregation {
+    Count,
+    Sum,
+    Avg,
+    P50,
+    P95,
+    P99,
+    Histogram,
+}
+
+impl Aggregation {
+    pub fn to_api_string(&self) -> &str {
+        match self {
+            Aggregation::Count => "count",
+            Aggregation::Sum => "sum",
+            Aggregation::Avg => "avg",
+            Aggregation::P50 => "p50",
+            Aggregation::P95 => "p95",
+            Aggregation::P99 => "p99",
+            Aggregation::Histogram => "histogram",
+        }
+    }
+}
+
+/// Time granularity options
+#[derive(Debug, Clone, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TimeGranularity {
+    Auto,
+    Minute,
+    Hour,
+    Day,
+    Week,
+    Month,
+}
+
+impl TimeGranularity {
+    pub fn to_api_string(&self) -> &str {
+        match self {
+            TimeGranularity::Auto => "auto",
+            TimeGranularity::Minute => "minute",
+            TimeGranularity::Hour => "hour",
+            TimeGranularity::Day => "day",
+            TimeGranularity::Week => "week",
+            TimeGranularity::Month => "month",
+        }
+    }
+}
+
+/// Observation type options
+#[derive(Debug, Clone, ValueEnum, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum ObservationType {
+    Generation,
+    Span,
+    Event,
+}
+
+impl ObservationType {
+    pub fn to_api_string(&self) -> &str {
+        match self {
+            ObservationType::Generation => "GENERATION",
+            ObservationType::Span => "SPAN",
+            ObservationType::Event => "EVENT",
+        }
+    }
+}
+
+/// A trace from Langfuse
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Trace {
+    pub id: String,
+    pub name: Option<String>,
+    pub user_id: Option<String>,
+    pub session_id: Option<String>,
+    pub release: Option<String>,
+    pub version: Option<String>,
+    pub metadata: Option<serde_json::Value>,
+    pub tags: Option<Vec<String>>,
+    pub input: Option<serde_json::Value>,
+    pub output: Option<serde_json::Value>,
+    pub timestamp: Option<String>,
+    #[serde(default)]
+    pub observations: Vec<Observation>,
+}
+
+/// A session from Langfuse
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Session {
+    pub id: String,
+    pub created_at: Option<String>,
+    pub project_id: Option<String>,
+    #[serde(default)]
+    pub traces: Vec<Trace>,
+}
+
+/// An observation from Langfuse
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Observation {
+    pub id: String,
+    pub trace_id: Option<String>,
+    pub r#type: Option<String>,
+    pub name: Option<String>,
+    pub start_time: Option<String>,
+    pub end_time: Option<String>,
+    pub model: Option<String>,
+    pub model_parameters: Option<serde_json::Value>,
+    pub input: Option<serde_json::Value>,
+    pub output: Option<serde_json::Value>,
+    pub metadata: Option<serde_json::Value>,
+    pub usage: Option<Usage>,
+    pub level: Option<String>,
+    pub status_message: Option<String>,
+    pub parent_observation_id: Option<String>,
+    pub completion_start_time: Option<String>,
+}
+
+/// Usage information for an observation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Usage {
+    pub input: Option<i64>,
+    pub output: Option<i64>,
+    pub total: Option<i64>,
+    pub unit: Option<String>,
+    pub input_cost: Option<f64>,
+    pub output_cost: Option<f64>,
+    pub total_cost: Option<f64>,
+}
+
+/// A score from Langfuse
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Score {
+    pub id: String,
+    pub trace_id: Option<String>,
+    pub observation_id: Option<String>,
+    pub name: Option<String>,
+    pub value: Option<serde_json::Value>,
+    pub source: Option<String>,
+    pub comment: Option<String>,
+    pub timestamp: Option<String>,
+    pub data_type: Option<String>,
+    pub string_value: Option<String>,
+}
+
+/// Metrics query result
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricsResult {
+    #[serde(default)]
+    pub data: Vec<HashMap<String, serde_json::Value>>,
+}
+
+/// API response wrapper for traces
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TracesResponse {
+    pub data: Vec<Trace>,
+    pub meta: Option<PaginationMeta>,
+}
+
+/// API response wrapper for sessions
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionsResponse {
+    pub data: Vec<Session>,
+    pub meta: Option<PaginationMeta>,
+}
+
+/// API response wrapper for observations
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ObservationsResponse {
+    pub data: Vec<Observation>,
+    pub meta: Option<PaginationMeta>,
+}
+
+/// API response wrapper for scores
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScoresResponse {
+    pub data: Vec<Score>,
+    pub meta: Option<PaginationMeta>,
+}
+
+/// Pagination metadata
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PaginationMeta {
+    pub page: Option<i32>,
+    pub limit: Option<i32>,
+    pub total_items: Option<i32>,
+    pub total_pages: Option<i32>,
+}


### PR DESCRIPTION
A Langfuse CLI.

Features:
- Configuration management with profile support (~/.langfuse/config.yml)
- Authentication via CLI flags, environment variables, or config file
- Multiple output formats: table, JSON, CSV, Markdown

Commands:
- config: setup, set, show, list profiles
- traces: list with filters, get by ID
- sessions: list, show with traces
- observations: list by type/trace/user, get by ID
- scores: list, get by ID
- metrics: query with aggregations and dimensions

Dependencies:
- clap for CLI parsing with derive macros
- reqwest for async HTTP client
- serde/serde_json/serde_yaml for serialization
- tokio for async runtime
- tabled for terminal table formatting
- dialoguer for interactive prompts